### PR TITLE
Fix := syntax in examples

### DIFF
--- a/example/assoc.bl
+++ b/example/assoc.bl
@@ -1,23 +1,23 @@
-def (K? to V?) : (Type, Type) -> Type do:
+def K? to V? : (Type, Type) -> Type =
     Map of [(K, V)]
 
-def (group pairs?) do:
+def group pairs? =
     match pairs with:
         () => ()
         x? :: y? :: xs? => (x, y) :: group xs
 
-def (map pairs...?) do:
+def map pairs...? =
     Map of group pairs
 
-def (m? find-key k?) do:
+def m? find-key k? =
     match m with:
         (k, v?) :: xs? => v
         e? :: xs? => xs find-key k
 
-def (m? find k?) : (Any to Any, Any) -> Any do:
+def m? find k? : (Any to Any, Any) -> Any =
     match m with:
         Map of xs? => xs find-key k
 
-def (m? with entry?) : (Any to Any, (Any, Any)) -> Any do:
+def m? with entry? : (Any to Any, (Any, Any)) -> Any =
     match m with:
         Map of xs? => Map of (entry :: xs)

--- a/example/fib.bl
+++ b/example/fib.bl
@@ -1,7 +1,9 @@
 # Computes fib(10) recursively.
 
-def fib (n? : Int) =
+def fib n? : Int =
     if n < 2 then 
         n 
     else 
         (fib n - 1) + (fib n - 2)
+
+println fib 10

--- a/example/match.bl
+++ b/example/match.bl
@@ -1,17 +1,17 @@
-def (xs? length) do:
+def xs? length =
     if xs == () then 0 else 1 + (xs tail length)
 
-def (xs? drop n?) do:
+def xs? drop n? =
     match n with:
         0 => xs
         n? => xs tail drop n - 1
     
-def (xs? take n?) do:
+def xs? take n? =
     match n with:
         0 => ()
         n? => xs head :: xs tail take n - 1
 
-def (merge a? b?) do:
+def merge a? b? =
     match (a, b) with:
         (a?, ()) => a
         ((), b?) => b
@@ -21,14 +21,14 @@ def (merge a? b?) do:
             else
                 b head :: (merge a b tail)
 
-def (sort items?) do:
+def sort items? =
     match items with:
         () => ()
         x? :: () => items
         xs? => do:
-            n := xs length
-            left := xs take n / 2
-            right := xs drop n / 2
+            def n = xs length
+            def left = xs take n / 2
+            def right = xs drop n / 2
             merge (sort left) (sort right)
 
 sort (list 4 7 5 2 3 0 1 9 8 6)

--- a/example/union.bl
+++ b/example/union.bl
@@ -1,9 +1,9 @@
-def (unpack x?) do:
+def unpack x? =
     match x with:
         i? : Int => "int!"
         s? : String => "string!"
 
-MyType := (Int | String)
-x := 1 : MyType
+def MyType = (Int | String)
+def x = 1 : MyType
 
-unpack x
+println unpack x


### PR DESCRIPTION
I tried to run some examples and got some issues. It seems that the syntax ":=" for assignments is no longer valid.
I figured out that "def __ =" worked, at least for the `union.bl` example.

The changes to `match.bl` seem correct, but I couldn't get it to sort the list.